### PR TITLE
Scale CMU near/far planes with scene size

### DIFF
--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -630,7 +630,19 @@ def readPanopticmeta(datadir: str, json_path: str):
 def readPanopticSportsinfos(datadir, images, eval, args):
     train_cam_infos, scene_radius, mean_center = readPanopticmeta(datadir, "train_meta.json")
     test_cam_infos, _, _ = readPanopticmeta(datadir, "test_meta.json")
-    
+
+    # Align camera near/far planes with the scene scale
+    near = scene_radius * 0.01
+    far = scene_radius * 5.0
+    args.near = near
+    args.far = far
+    for cam_info in train_cam_infos:
+        cam_info.near = near
+        cam_info.far = far
+    for cam_info in test_cam_infos:
+        cam_info.near = near
+        cam_info.far = far
+
     # Subtract mean_center from camera positions before scaling
     for cam_info in train_cam_infos:
         cam_info.T = cam_info.T - mean_center.flatten()


### PR DESCRIPTION
## Summary
- Scale CMU Panoptic near and far clip planes based on scene radius
- Update dataset arguments and per-camera parameters to use the normalized depth range

## Testing
- `python -m py_compile scene/dataset_readers.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbfcdb0f908320985e94646f9a6feb